### PR TITLE
Update versioning paths in .goreleaser.yaml and Makefile

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,9 +10,9 @@ builds:
     binary: goct
     ldflags:
       - -s -w
-      - -X github.com/kmdkuk/goct/pkg/version.Version={{.Version}}
-      - -X github.com/kmdkuk/goct/pkg/version.Revision={{.ShortCommit}}
-      - -X github.com/kmdkuk/goct/pkg/version.BuildDate={{.Date}}
+      - -X github.com/kmdkuk/pucy/internal/version.Version={{.Version}}
+      - -X github.com/kmdkuk/pucy/internal/version.Revision={{.ShortCommit}}
+      - -X github.com/kmdkuk/pucy/internal/version.BuildDate={{.Date}}
     goos:
       - windows
       - darwin

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,10 @@ ifndef CGO_LDFLAGS
 	export CGO_LDFLAGS := $(LDFLAGS)
 endif
 
-GO_LDFLAGS := -X github.com/kmdkuk/goct/pkg/version.Revision=$(REVISION) $(GO_LDFLAGS)
-GO_LDFLAGS := -X github.com/kmdkuk/goct/pkg/version.BuildDate=$(BUILD_DATE) $(GO_LDFLAGS)
+GO_LDFLAGS := -X github.com/kmdkuk/pucy/internal/version.Revision=$(REVISION) $(GO_LDFLAGS)
+GO_LDFLAGS := -X github.com/kmdkuk/pucy/internal/version.BuildDate=$(BUILD_DATE) $(GO_LDFLAGS)
 DEV_LDFLAGS := $(GO_LDFLAGS)
-GO_LDFLAGS := -X github.com/kmdkuk/goct/pkg/version.Version=$(VERSION) $(GO_LDFLAGS)
+GO_LDFLAGS := -X github.com/kmdkuk/pucy/internal/version.Version=$(VERSION) $(GO_LDFLAGS)
 
 # Tools path
 BIN_DIR := $(CURDIR)/bin


### PR DESCRIPTION
Change versioning paths to reflect the new package structure for proper versioning during builds.