### PR TITLE
Add .vscode directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ go.work.sum
 .env
 
 bin/
+
+.vscode/


### PR DESCRIPTION
Include the .vscode directory in .gitignore to prevent it from being tracked by Git.