### PR TITLE
Update binary name from 'goct' to 'pucy'

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,7 @@ before:
     - go mod tidy
 builds:
   - main: .
-    binary: goct
+    binary: pucy
     ldflags:
       - -s -w
       - -X github.com/kmdkuk/pucy/internal/version.Version={{.Version}}


### PR DESCRIPTION
Change the binary name in the .goreleaser.yaml configuration to reflect the new naming convention.